### PR TITLE
Condition Builder: replacing conditions order fix

### DIFF
--- a/src/classes/QueryBuilder.cls
+++ b/src/classes/QueryBuilder.cls
@@ -1815,7 +1815,7 @@ public virtual inherited sharing class QueryBuilder {
             this.conditions.size();
             for (Integer i = 1; i <= this.conditions.size(); i++) {
                 String conditionNumber = '' + i;
-                conditions = conditions.replace(conditionNumber, this.bracket(conditionNumber));
+                conditions = conditions.replaceFirst(conditionNumber, this.bracket(conditionNumber));
             }
             return conditions;
         }


### PR DESCRIPTION
condition builder was fixed to handle more than 9 conditions per query; There was an issue while replacing numbers in conditionOrder string. 

Example of an issue:

`String conditionOrder = '1 AND 2 AND 3 AND 4 AND 5 AND 5 AND 6 AND 7 AND 8 AND 9 AND 10';
conditionOrder.replace('1', '{1}');`

`1` and first symbol of `10` will be replaced by `{1}` that will cause a problem with tenth condition